### PR TITLE
Only mark conversations as seen when they have focus

### DIFF
--- a/googlechat_conversation.c
+++ b/googlechat_conversation.c
@@ -2116,6 +2116,9 @@ googlechat_mark_conversation_seen(PurpleConversation *conv, PurpleConversationUp
 	if (type != PURPLE_CONVERSATION_UPDATE_UNSEEN)
 		return;
 	
+	if (!purple_conversation_has_focus(conv))
+		return;
+	
 	pc = purple_conversation_get_connection(conv);
 	if (!PURPLE_CONNECTION_IS_CONNECTED(pc))
 		return;


### PR DESCRIPTION
It looks like `googlechat_mark_conversation_seen()` is intended to mainly be called on line 372 of `googlechat_events.c` inside an `if(purple_conversation_has_focus())` test, however that code path doesn't seem to be getting hit for me and instead it's primarily called via line 401 of `libgooglechat.c` as a direct callback of the `conversation-updated` event where there is no test for focus.

Unsure what the intent is (and weirdly `conversation-updated` doesn't seem to fire on sending a message, just receiving, so with this patch our user is often shown as not having seen their own last message) but this at least prevents the current behavior of overzealously marking everything as seen.