### PR TITLE
When sending messages, don't force RetentionState to PERMANENT

### DIFF
--- a/googlechat_conversation.c
+++ b/googlechat_conversation.c
@@ -1733,8 +1733,8 @@ googlechat_conversation_send_message(GoogleChatAccount *ha, const gchar *conv_id
 	
 	retention_settings__init(&retention_settings);
 	request.retention_settings = &retention_settings;
-	retention_settings.has_state = TRUE;
-	retention_settings.state = RETENTION_SETTINGS__RETENTION_STATE__PERMANENT;
+	// TODO: set retention state based on conversation's history setting?
+	retention_settings.has_state = FALSE;
 	
 	message_info__init(&message_info);
 	request.message_info = &message_info;


### PR DESCRIPTION
This allows sending messages to conversations where history is off.  Lightly tested with DMs with conversation history both on and off.

Fixes #22, though I don't know if this is how you want to do this (as opposed to fetching the history setting for the conversation and setting RetentionState accordingly).