### PR TITLE
Fix compilation on pre-C11 compilers.

### DIFF
--- a/googlechat_connection.h
+++ b/googlechat_connection.h
@@ -61,8 +61,9 @@ typedef void(* GoogleChatApiResponseFunc)(GoogleChatAccount *ha, ProtobufCMessag
 void googlechat_api_request(GoogleChatAccount *ha, const gchar *endpoint, ProtobufCMessage *request, GoogleChatApiResponseFunc callback, ProtobufCMessage *response_message, gpointer user_data);
 
 
-#define GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC(name, request_type, response_name, type, url) \
-typedef void(* GoogleChatApi##type##ResponseFunc)(GoogleChatAccount *ha, type##Response *response, gpointer user_data);\
+#define GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC_TYPEDEF(name, request_type, response_name, type, url) \
+typedef void(* GoogleChatApi##type##ResponseFunc)(GoogleChatAccount *ha, type##Response *response, gpointer user_data);
+#define GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC_FUNC(name, request_type, response_name, type, url) \
 static inline void \
 googlechat_api_##name(GoogleChatAccount *ha, request_type##Request *request, GoogleChatApi##type##ResponseFunc callback, gpointer user_data)\
 {\
@@ -71,6 +72,10 @@ googlechat_api_##name(GoogleChatAccount *ha, request_type##Request *request, Goo
 	response_name##_response__init(response);\
 	googlechat_api_request(ha, "/api/" url "?rt=b", (ProtobufCMessage *)request, (GoogleChatApiResponseFunc)callback, (ProtobufCMessage *)response, user_data);\
 }
+
+#define GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC(name, request_type, response_name, type, url) \
+	GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC_TYPEDEF(name, request_type, response_name, type, url) \
+	GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC_FUNC(name, request_type, response_name, type, url)
 
 #define GOOGLECHAT_DEFINE_API_REQUEST_FUNC(name, type, url) \
 	GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC(name, type, name, type, url)
@@ -83,7 +88,7 @@ GOOGLECHAT_DEFINE_API_REQUEST_FUNC(list_topics, ListTopics, "list_topics");
 GOOGLECHAT_DEFINE_API_REQUEST_FUNC(get_user_presence, GetUserPresence, "get_user_presence");
 GOOGLECHAT_DEFINE_API_REQUEST_FUNC(get_self_user_status, GetSelfUserStatus, "get_self_user_status");
 GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC(catch_up_group, CatchUpGroup, catch_up, CatchUp, "catch_up_group");
-GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC(catch_up_user, CatchUpUser, catch_up, CatchUp, "catch_up_user");
+GOOGLECHAT_DEFINE_API_REQUEST_RESPONSE_FUNC_FUNC(catch_up_user, CatchUpUser, catch_up, CatchUp, "catch_up_user");
 GOOGLECHAT_DEFINE_API_REQUEST_FUNC(get_group, GetGroup, "get_group");
 GOOGLECHAT_DEFINE_API_REQUEST_FUNC(create_group, CreateGroup, "create_group");
 GOOGLECHAT_DEFINE_API_REQUEST_FUNC(create_dm, CreateDm, "create_dm");


### PR DESCRIPTION
Older C compilers that do not implement C11 choke on repeated typedef
declarations:

```
In file included from libgooglechat.c:32:
googlechat_connection.h:86: error: redefinition of typedef ‘GoogleChatApiCatchUpResponseFunc’
googlechat_connection.h:85: note: previous declaration of ‘GoogleChatApiCatchUpResponseFunc’ was here
```

This patch reworks the code to avoid repeating the
`GoogleChatApiCatchUpResponseFunc` typedef.  Feel free to implement
another mechanism; preprocessor macros are not exactly flexible and that
approach was the least ugly I could think of.