### PR TITLE
Don't create buddies that are hidden or blocked.

### DIFF
--- a/googlechat_conversation.c
+++ b/googlechat_conversation.c
@@ -962,12 +962,12 @@ googlechat_got_conversation_list(GoogleChatAccount *ha, PaginatedWorldResponse *
 				other_person = world_item_lite->dm_members->members[1]->id;
 				// participant_num = 1;
 			}
+
+			PurpleBuddy *buddy = purple_blist_find_buddy(ha->account, other_person);
 			
 			if (!world_item_lite->read_state->hide_timestamp && !world_item_lite->read_state->blocked) {
 				g_hash_table_replace(ha->one_to_ones, g_strdup(conv_id), g_strdup(other_person));
 				g_hash_table_replace(ha->one_to_ones_rev, g_strdup(other_person), g_strdup(conv_id));
-
-				PurpleBuddy *buddy = purple_blist_find_buddy(ha->account, other_person);
 				if (!buddy) {
 					googlechat_add_person_to_blist(ha, other_person, other_person_alias);
 				} else {
@@ -982,6 +982,8 @@ googlechat_got_conversation_list(GoogleChatAccount *ha, PaginatedWorldResponse *
 				}
 
 				g_hash_table_replace(unique_user_ids, other_person, NULL);
+			} else if (buddy) {
+				purple_blist_remove_buddy(buddy);
 			}
 			
 		} else {

--- a/googlechat_conversation.c
+++ b/googlechat_conversation.c
@@ -1956,16 +1956,18 @@ googlechat_chat_leave_by_conv_id(PurpleConnection *pc, const gchar *conv_id, con
 	
 	remove_memberships_request__init(&request);
 	
+	member_id__init(&member_id);
+	user_id__init(&user_id);
+	member_id.user_id = &user_id;
+
 	if (who != NULL) {
-		member_id__init(&member_id);
-		user_id__init(&user_id);
-		member_id.user_id = &user_id;
-		
 		user_id.id = (gchar *) who;
-		member_ids = &member_id;
-		request.member_ids = &member_ids;
-		request.n_member_ids = 1;
+	} else {
+		user_id.id = ha->self_gaia_id;
 	}
+	member_ids = &member_id;
+	request.member_ids = &member_ids;
+	request.n_member_ids = 1;
 	
 	group_id__init(&group_id);
 	request.group_id = &group_id;

--- a/googlechat_conversation.c
+++ b/googlechat_conversation.c
@@ -963,24 +963,26 @@ googlechat_got_conversation_list(GoogleChatAccount *ha, PaginatedWorldResponse *
 				// participant_num = 1;
 			}
 			
-			g_hash_table_replace(ha->one_to_ones, g_strdup(conv_id), g_strdup(other_person));
-			g_hash_table_replace(ha->one_to_ones_rev, g_strdup(other_person), g_strdup(conv_id));
+			if (!world_item_lite->read_state->hide_timestamp && !world_item_lite->read_state->blocked) {
+				g_hash_table_replace(ha->one_to_ones, g_strdup(conv_id), g_strdup(other_person));
+				g_hash_table_replace(ha->one_to_ones_rev, g_strdup(other_person), g_strdup(conv_id));
+
+				PurpleBuddy *buddy = purple_blist_find_buddy(ha->account, other_person);
+				if (!buddy) {
+					googlechat_add_person_to_blist(ha, other_person, other_person_alias);
+				} else {
+					if (other_person_alias && *other_person_alias) {
+						purple_blist_server_alias_buddy(buddy, other_person_alias);
 			
-			PurpleBuddy *buddy = purple_blist_find_buddy(ha->account, other_person);
-			if (!buddy) {
-				googlechat_add_person_to_blist(ha, other_person, other_person_alias);
-			} else {
-				if (other_person_alias && *other_person_alias) {
-					purple_blist_server_alias_buddy(buddy, other_person_alias);
-		
-					const gchar *balias = purple_buddy_get_local_buddy_alias(buddy);
-					if ((!balias || !*balias) && !purple_strequal(balias, other_person_alias)) {
-						purple_blist_alias_buddy(buddy, other_person_alias);
+						const gchar *balias = purple_buddy_get_local_buddy_alias(buddy);
+						if ((!balias || !*balias) && !purple_strequal(balias, other_person_alias)) {
+							purple_blist_alias_buddy(buddy, other_person_alias);
+						}
 					}
 				}
+
+				g_hash_table_replace(unique_user_ids, other_person, NULL);
 			}
-			
-			g_hash_table_replace(unique_user_ids, other_person, NULL);
 			
 		} else {
 			PurpleChat *chat = purple_blist_find_chat(ha->account, conv_id);

--- a/googlechat_conversation.c
+++ b/googlechat_conversation.c
@@ -965,7 +965,7 @@ googlechat_got_conversation_list(GoogleChatAccount *ha, PaginatedWorldResponse *
 
 			PurpleBuddy *buddy = purple_blist_find_buddy(ha->account, other_person);
 			
-			if (!world_item_lite->read_state->hide_timestamp && !world_item_lite->read_state->blocked) {
+			if (!world_item_lite->read_state->hide_timestamp) {
 				g_hash_table_replace(ha->one_to_ones, g_strdup(conv_id), g_strdup(other_person));
 				g_hash_table_replace(ha->one_to_ones_rev, g_strdup(other_person), g_strdup(conv_id));
 				if (!buddy) {


### PR DESCRIPTION
Described in https://github.com/EionRobb/purple-googlechat/issues/37, there is an issues where unwanted buddies show up in the buddy list, and if you remove them, they reappear the next time you restart pidgin, or reconnect to Google Chat.

This is because the API we are using shows every DM session we have ever had, and while we are being told which of them has been hidden, or blocked, up until now the plugin has ignored those flags.

This fixes that, only bothering to add buddies that are neither hidden nor blocked.

This finally allows someone to remove a buddy (which internally to the plug hides the buddy), and have them stay gone.