### PR TITLE
Attempt login using cookies from browser

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: Mozilla
+IndentWidth: 4
+TabWidth: 4
+UseTab: Always
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+AlwaysBreakAfterDefinitionReturnType: All
+ColumnLimit: 0
+PointerAlignment: Right
+SpaceAfterCStyleCast: true
+AlignTrailingComments: true

--- a/glibcompat.h
+++ b/glibcompat.h
@@ -1,10 +1,13 @@
 #ifndef _GLIBCOMPAT_H_
 #define _GLIBCOMPAT_H_
 
+#if !GLIB_CHECK_VERSION(2, 68, 0)
+#define g_memdup2(mem, size) g_memdup((mem), (size))
+#endif /* 2.68.0 */
+
 #if !GLIB_CHECK_VERSION(2, 32, 0)
 #define g_hash_table_contains(hash_table, key) g_hash_table_lookup_extended(hash_table, key, NULL, NULL)
 #endif /* 2.32.0 */
-
 
 #if !GLIB_CHECK_VERSION(2, 28, 0)
 gint64

--- a/googlechat_auth.c
+++ b/googlechat_auth.c
@@ -268,12 +268,37 @@ googlechat_oauth_with_code(GoogleChatAccount *ha, const gchar *auth_code)
 
 /*****************************************************************************/
 
+void
+googlechat_auth_finished_auth(GoogleChatAccount *ha)
+{
+	guint64 last_event_timestamp;
+
+	//Restore the last_event_timestamp before it gets overridden by new events
+	last_event_timestamp = purple_account_get_int(ha->account, "last_event_timestamp_high", 0);
+	if (last_event_timestamp != 0) {
+		last_event_timestamp = (last_event_timestamp << 32) | ((guint64) purple_account_get_int(ha->account, "last_event_timestamp_low", 0) & 0xFFFFFFFF);
+		ha->last_event_timestamp = last_event_timestamp;
+	}
+	
+	// SOUND THE TRUMPETS
+	//googlechat_fetch_channel_sid(ha);
+	googlechat_register_webchannel(ha);
+	purple_connection_set_state(ha->pc, PURPLE_CONNECTION_CONNECTED);
+	
+	//TODO trigger event instead
+	googlechat_get_self_user_status(ha);
+	googlechat_get_conversation_list(ha);
+	
+	if (ha->poll_buddy_status_timeout) {
+		g_source_remove(ha->poll_buddy_status_timeout);
+	}
+	ha->poll_buddy_status_timeout = g_timeout_add_seconds(120, googlechat_poll_buddy_status, ha);
+}
 
 void
 googlechat_auth_get_dynamite_token_cb(PurpleHttpConnection *http_conn, PurpleHttpResponse *response, gpointer user_data)
 {
 	GoogleChatAccount *ha = user_data;
-	guint64 last_event_timestamp;
 	JsonObject *obj;
 	const gchar *raw_response;
 	gsize response_len;
@@ -296,26 +321,7 @@ googlechat_auth_get_dynamite_token_cb(PurpleHttpConnection *http_conn, PurpleHtt
 	g_free(ha->access_token);
 	ha->access_token = g_strdup(json_object_get_string_member(obj, "token"));
 	
-	//Restore the last_event_timestamp before it gets overridden by new events
-	last_event_timestamp = purple_account_get_int(ha->account, "last_event_timestamp_high", 0);
-	if (last_event_timestamp != 0) {
-		last_event_timestamp = (last_event_timestamp << 32) | ((guint64) purple_account_get_int(ha->account, "last_event_timestamp_low", 0) & 0xFFFFFFFF);
-		ha->last_event_timestamp = last_event_timestamp;
-	}
-	
-	// SOUND THE TRUMPETS
-	//googlechat_fetch_channel_sid(ha);
-	googlechat_register_webchannel(ha);
-	purple_connection_set_state(ha->pc, PURPLE_CONNECTION_CONNECTED);
-	
-	//TODO trigger event instead
-	googlechat_get_self_user_status(ha);
-	googlechat_get_conversation_list(ha);
-	
-	if (ha->poll_buddy_status_timeout) {
-		g_source_remove(ha->poll_buddy_status_timeout);
-	}
-	ha->poll_buddy_status_timeout = g_timeout_add_seconds(120, googlechat_poll_buddy_status, ha);
+	googlechat_auth_finished_auth(ha);
 	
 	gint expires_in = atoi(json_object_get_string_member(obj, "expiresIn"));
 	if (expires_in > 30) {
@@ -356,6 +362,90 @@ googlechat_auth_get_dynamite_token(GoogleChatAccount *ha)
 	g_string_free(postdata, TRUE);
 	
 	return FALSE;
+}
+
+static void
+googlechat_auth_refresh_xsrf_token_cb(PurpleHttpConnection *http_conn, PurpleHttpResponse *response, gpointer user_data)
+{
+	GoogleChatAccount *ha = user_data;
+	JsonObject *obj;
+	const gchar *raw_response;
+	gsize response_len;
+	const gchar *wiz_data_start, *wiz_data_end;
+	gchar *wiz_data;
+
+	if (!purple_http_response_is_successful(response)) {
+		purple_connection_error(ha->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR,
+			purple_http_response_get_error(response));
+		return;
+	}
+
+	raw_response = purple_http_response_get_data(response, &response_len);
+
+	wiz_data_start = strstr(raw_response, ">window.WIZ_global_data = ");
+	if (wiz_data_start == NULL) {
+		purple_connection_error(ha->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR,
+			_("Invalid response"));
+		return;
+	}
+	wiz_data_start += 25; // length of ">window.WIZ_global_data = "
+	wiz_data_end = strstr(wiz_data_start, ";</script>");
+	if (wiz_data_end == NULL || wiz_data_end > raw_response + response_len) {
+		purple_connection_error(ha->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR,
+			_("Invalid response"));
+		return;
+	}
+	wiz_data = g_strndup(wiz_data_start, wiz_data_end - wiz_data_start);
+
+	obj = json_decode_object(wiz_data, -1);
+
+	if (obj) {
+		gchar *xsrf_token = g_strdup(json_object_get_string_member(obj, "SMqcke"));
+		if (ha->xsrf_token) {
+			g_free(ha->xsrf_token);
+		}
+		ha->xsrf_token = xsrf_token;
+	} else {
+		purple_connection_error(ha->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR,
+			_("Invalid response"));
+	}
+
+	json_object_unref(obj);
+	g_free(wiz_data);
+
+	googlechat_auth_finished_auth(ha);
+}
+
+void
+googlechat_auth_refresh_xsrf_token(GoogleChatAccount *ha)
+{
+	PurpleHttpRequest *request;
+	PurpleConnection *pc;
+	GString *url;
+
+	pc = ha->pc;
+	if (!PURPLE_IS_CONNECTION(pc)) {
+		return;
+	}
+
+	// from https://github.com/mautrix/googlechat/blob/master/maugclib/client.py
+	url = g_string_new("https://chat.google.com/mole/world?");
+	g_string_append_printf(url, "origin=%s&", purple_url_encode("https://mail.google.com"));
+	g_string_append_printf(url, "shell=%s&", purple_url_encode("9"));
+	g_string_append_printf(url, "hl=%s&", purple_url_encode("en"));
+	g_string_append_printf(url, "wfi=%s&", purple_url_encode("gtn-roster-iframe-id"));
+	g_string_append_printf(url, "hs=%s&", purple_url_encode("[\"h_hs\",null,null,[1,0],null,null,\"gmail.pinto-server_20230730.06_p0\",1,null,[15,38,36,35,26,30,41,18,24,11,21,14,6],null,null,\"3Mu86PSulM4.en..es5\",0,null,null,[0]]"));
+
+	request = purple_http_request_new(url->str);
+	purple_http_request_set_cookie_jar(request, ha->cookie_jar);
+	purple_http_request_set_method(request, "GET");
+	purple_http_request_header_set(request, "Referer", "https://mail.google.com/");
+	purple_http_request_header_set_printf(request, "User-Agent", GOOGLECHAT_USER_AGENT);
+
+	purple_http_request(pc, request, googlechat_auth_refresh_xsrf_token_cb, ha);
+	purple_http_request_unref(request);
+	
+	g_string_free(url, TRUE);
 }
 
 

--- a/googlechat_auth.h
+++ b/googlechat_auth.h
@@ -26,6 +26,6 @@ void googlechat_oauth_with_code(GoogleChatAccount *ha, const gchar *auth_code);
 gboolean googlechat_oauth_refresh_token(GoogleChatAccount *ha);
 void googlechat_cache_ssl_certs(GoogleChatAccount *ha);
 void googlechat_auth_finished_auth(GoogleChatAccount *ha);
-void googlechat_auth_refresh_xsrf_token(GoogleChatAccount *ha);
+gboolean googlechat_auth_refresh_xsrf_token(GoogleChatAccount *ha);
 
 #endif /*_GOOGLECHAT_AUTH_H_*/

--- a/googlechat_auth.h
+++ b/googlechat_auth.h
@@ -25,5 +25,7 @@
 void googlechat_oauth_with_code(GoogleChatAccount *ha, const gchar *auth_code);
 gboolean googlechat_oauth_refresh_token(GoogleChatAccount *ha);
 void googlechat_cache_ssl_certs(GoogleChatAccount *ha);
+void googlechat_auth_finished_auth(GoogleChatAccount *ha);
+void googlechat_auth_refresh_xsrf_token(GoogleChatAccount *ha);
 
 #endif /*_GOOGLECHAT_AUTH_H_*/

--- a/googlechat_connection.h
+++ b/googlechat_connection.h
@@ -31,6 +31,7 @@
 #define GOOGLECHAT_PBLITE_XORIGIN_URL "https://chat.google.com"
 #define GOOGLECHAT_PBLITE_API_URL "https://chat.google.com"
 #define GOOGLECHAT_CHANNEL_URL_PREFIX "https://chat.google.com/webchannel/"
+#define GOOGLECHAT_USER_AGENT "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
 
 void googlechat_process_data_chunks(GoogleChatAccount *ha, const gchar *data, gsize len);
 

--- a/googlechat_conversation.c
+++ b/googlechat_conversation.c
@@ -1106,7 +1106,7 @@ googlechat_got_buddy_photo(PurpleHttpConnection *connection, PurpleHttpResponse 
 	}
 	
 	response_str = purple_http_response_get_data(response, &response_len);
-	response_dup = g_memdup(response_str, response_len);
+	response_dup = g_memdup2(response_str, response_len);
 	purple_buddy_icons_set_for_user(account, name, response_dup, response_len, photo_url);
 }
 

--- a/googlechat_events.c
+++ b/googlechat_events.c
@@ -266,7 +266,7 @@ googlechat_got_http_image_for_conv(PurpleHttpConnection *connection, PurpleHttpR
 	message_timestamp = GPOINTER_TO_INT(g_dataset_get_data(connection, "message_timestamp"));
 	
 	response_data = purple_http_response_get_data(response, &response_size);
-	image = purple_image_new_from_data(g_memdup(response_data, response_size), response_size);
+	image = purple_image_new_from_data(g_memdup2(response_data, response_size), response_size);
 	image_id = purple_image_store_add(image);
 	escaped_image_url = g_markup_escape_text(purple_http_request_get_url(purple_http_conn_get_request(connection)), -1);
 	if (drive_url) {

--- a/libgooglechat.c
+++ b/libgooglechat.c
@@ -429,6 +429,7 @@ googlechat_login(PurpleAccount *account)
 		googlechat_try_get_cookie_value("HSID");
 
 		googlechat_auth_refresh_xsrf_token(ha);
+		ha->refresh_token_timeout = g_timeout_add_seconds(86400, (GSourceFunc) googlechat_auth_refresh_xsrf_token, ha);
 	}
 	
 	purple_signal_connect(purple_blist_get_handle(), "blist-node-removed", account, PURPLE_CALLBACK(googlechat_blist_node_removed), NULL);

--- a/libgooglechat.h
+++ b/libgooglechat.h
@@ -89,6 +89,7 @@ typedef struct {
 	gchar *client_id;
 	gchar *self_gaia_id;
 	gchar *self_phone;
+	gchar *xsrf_token;
 	
 	gint64 last_event_timestamp;
 	PurpleConversation *last_conversation_focused;

--- a/purple2compat/glibcompat.h
+++ b/purple2compat/glibcompat.h
@@ -1,0 +1,4 @@
+
+#if !GLIB_CHECK_VERSION(2, 68, 0)
+#define g_memdup2(mem,size) g_memdup((mem),(size))
+#endif

--- a/purple2compat/http.h
+++ b/purple2compat/http.h
@@ -64,7 +64,7 @@ typedef struct _PurpleHttpURL PurpleHttpURL;
 /**
  * PurpleHttpCookieJar:
  *
- * An collection of cookies, got from HTTP response or provided for HTTP
+ * A collection of cookies, got from HTTP response or provided for HTTP
  * request.
  */
 typedef struct _PurpleHttpCookieJar PurpleHttpCookieJar;
@@ -86,7 +86,7 @@ typedef struct _PurpleHttpConnectionSet PurpleHttpConnectionSet;
 /**
  * PurpleHttpCallback:
  *
- * An callback called after performing (successfully or not) HTTP request.
+ * A callback called after performing (successfully or not) HTTP request.
  */
 typedef void (*PurpleHttpCallback)(PurpleHttpConnection *http_conn,
 	PurpleHttpResponse *response, gpointer user_data);
@@ -94,7 +94,7 @@ typedef void (*PurpleHttpCallback)(PurpleHttpConnection *http_conn,
 /**
  * PurpleHttpContentReaderCb:
  *
- * An callback called after storing data requested by PurpleHttpContentReader.
+ * A callback called after storing data requested by PurpleHttpContentReader.
  */
 typedef void (*PurpleHttpContentReaderCb)(PurpleHttpConnection *http_conn,
 	gboolean success, gboolean eof, size_t stored);
@@ -108,7 +108,7 @@ typedef void (*PurpleHttpContentReaderCb)(PurpleHttpConnection *http_conn,
  * @user_data: The user data passed with callback function.
  * @cb:        The function to call after storing data to buffer.
  *
- * An callback for getting large request contents (ie. from file stored on
+ * A callback for getting large request contents (ie. from file stored on
  * disk).
  */
 typedef void (*PurpleHttpContentReader)(PurpleHttpConnection *http_conn,
@@ -125,7 +125,7 @@ typedef void (*PurpleHttpContentReader)(PurpleHttpConnection *http_conn,
  * @length:    Length of data read.
  * @user_data: The user data passed with callback function.
  *
- * An callback for writting large response contents.
+ * A callback for writing large response contents.
  *
  * Returns:          TRUE, if succeeded, FALSE otherwise.
  */
@@ -142,7 +142,7 @@ typedef gboolean (*PurpleHttpContentWriter)(PurpleHttpConnection *http_conn,
  * @total:         Total amount of data (in current state).
  * @user_data:     The user data passed with callback function.
  *
- * An callback for watching HTTP connection progress.
+ * A callback for watching HTTP connection progress.
  */
 typedef void (*PurpleHttpProgressWatcher)(PurpleHttpConnection *http_conn,
 	gboolean reading_state, int processed, int total, gpointer user_data);
@@ -175,7 +175,7 @@ PurpleHttpConnection * purple_http_get(PurpleConnection *gc,
  * @user_data: The user data to pass to the callback function.
  * @format:    The format string.
  *
- * Constructs an URL and fetches the data from it with GET request, then passes
+ * Constructs a URL and fetches the data from it with GET request, then passes
  * it to a callback function.
  *
  * Returns:          The HTTP connection struct.
@@ -191,7 +191,7 @@ PurpleHttpConnection * purple_http_get_printf(PurpleConnection *gc,
  * @callback:  (scope call): The callback function.
  * @user_data: The user data to pass to the callback function.
  *
- * Fetches a HTTP request and passes the response to a callback function.
+ * Fetches an HTTP request and passes the response to a callback function.
  * Provided request struct can be shared by multiple http requests but can not
  * be modified when any of these is running.
  *
@@ -530,7 +530,7 @@ void purple_http_request_set_url(PurpleHttpRequest *request, const gchar *url);
  * @request: The request.
  * @format:  The format string.
  *
- * Constructs and sets an URL for HTTP request.
+ * Constructs and sets a URL for HTTP request.
  */
 void purple_http_request_set_url_printf(PurpleHttpRequest *request,
 	const gchar *format, ...) G_GNUC_PRINTF(2, 3);
@@ -600,8 +600,17 @@ purple_http_request_get_keepalive_pool(PurpleHttpRequest *request);
  * Sets contents of HTTP request (for example, POST data).
  */
 void purple_http_request_set_contents(PurpleHttpRequest *request,
-	const gchar *contents, int length);
+	const gchar *contents, gssize length);
 
+/**
+ * purple_http_request_get_contents:
+ * @request: The request.
+ *
+ * Gets HTTP postdata set for the request.
+ *
+ * Returns:        The contents.
+ */
+const gchar * purple_http_request_get_contents(PurpleHttpRequest *request);
 /**
  * purple_http_request_set_contents_reader:
  * @request:              The request.
@@ -613,7 +622,7 @@ void purple_http_request_set_contents(PurpleHttpRequest *request,
  * uploads.
  */
 void purple_http_request_set_contents_reader(PurpleHttpRequest *request,
-	PurpleHttpContentReader reader, int contents_length, gpointer user_data);
+	PurpleHttpContentReader reader, gsize contents_length, gpointer user_data);
 
 /**
  * purple_http_request_set_response_writer:

--- a/purple2compat/image-store.h
+++ b/purple2compat/image-store.h
@@ -6,7 +6,7 @@
 
 
 #define purple_image_store_add(img)  purple_imgstore_add_with_id( \
-	g_memdup(purple_imgstore_get_data(img), purple_imgstore_get_size(img)), \
+	g_memdup2(purple_imgstore_get_data(img), purple_imgstore_get_size(img)), \
 	purple_imgstore_get_size(img), purple_imgstore_get_filename(img))
 #define purple_image_store_get       purple_imgstore_find_by_id
 


### PR DESCRIPTION
Follow directions from https://docs.mau.fi/bridges/python/googlechat/authentication.html the 'Advanced' tab as settings

> 1. Open https://chat.google.com/ in a private browser window and log in normally, then extract cookies:
> 2. Press F12 to open developer tools.
> 3. select the "Application" (Chrome) or "Storage" (Firefox) tab.
> 4. In the sidebar, expand "Cookies" and select https://chat.google.com.
> 5. In the cookie list, find the COMPASS, SSID, SID, OSID and HSID rows.
> 6. When using Firefox, you may have multiple COMPASS cookies with different paths. Pick the one where path is /.
> 7. Form a JSON object with the extracted cookies. It should look something like this (field names are case-insensitive):
> ```
>{
>  "compass": "dynamite-ui=...",
>  "ssid": "...",
>  "sid": "...",
>  "osid": "...",
>  "hsid": "..."
>}
>```
>8. Close the browser window to prevent the cookies being invalidated (Google uses refresh tokens, so you need to close the window within a few minutes).

There's also a handy extension https://github.com/mautrix/googlechat/issues/93#issuecomment-1689792422
> Firefox: [addons.mozilla.org/en-US/firefox/addon/gchat-login-cookie-generator](https://addons.mozilla.org/en-US/firefox/addon/gchat-login-cookie-generator/) and
> Chromium based browsers: [chrome.google.com/webstore/detail/matrix-gchat-bridge-login/mofmfbkepponmdchhamalbcldoajbmho](https://chrome.google.com/webstore/detail/matrix-gchat-bridge-login/mofmfbkepponmdchhamalbcldoajbmho)

Other people in the comments of https://github.com/mautrix/googlechat/issues/93 have said they had to use a fresh "Guest Profile" in Chrome